### PR TITLE
Fix typo and incorrect type in responses.go

### DIFF
--- a/responses/responses.go
+++ b/responses/responses.go
@@ -193,7 +193,7 @@ type Station struct {
 	StationSharingURL  string   `json:"stationSharingUrl"`
 	QuickMixStationIDs []string `json:"quickMixStationIds"`
 	Feedback           struct {
-		ThumbsDown []FeedbackResponse `json:"thumsDown"`
+		ThumbsDown []FeedbackResponse `json:"thumbsDown"`
 		ThumbsUp   []FeedbackResponse `json:"thumbsUp"`
 	} `json:"feedback"`
 }
@@ -223,7 +223,7 @@ type UserGetBookmarks struct {
 type UserGetStationList struct {
 	Result struct {
 		Stations StationList `json:"stations"`
-		Checksum string    `json:"checksum"`
+		Checksum string      `json:"checksum"`
 	} `json:"result"`
 }
 
@@ -257,7 +257,7 @@ type FeedbackResponse struct {
 	SongName    string       `json:"songName"`
 	DateCreated DateResponse `json:"dateCreated"`
 	FeedbackID  string       `json:"feedbackId"`
-	IsPositive  int          `json:"isPositive"`
+	IsPositive  bool         `json:"isPositive"`
 }
 
 type StationAddFeedback struct {


### PR DESCRIPTION
I'm working on a tool that exports your favourite songs from Pandora as JSON.

Your library has made this really easy but I did have to change `FeedbackResponse.IsPositive` to type `bool` to get it to work.

This is what I was doing to cause the error (simplified):

``` go
package main

import "github.com/cellofellow/gopiano"

func main() {
    username := "username"
    password := "password"

    // just setting up a new client
    client, _ := gopiano.NewClient(gopiano.AndroidClient)
    client.AuthPartnerLogin()
    client.AuthUserLogin(username, password)

    // getting the stations
    stationsResult, _ := client.UserGetStationList(false)
    stations := stationsResult.Result.Stations

    // assuming station exists and has at least one feedback response
    station := stations[2]

    // panic occurs during unmarshalling of response
    _, err := client.StationGetStation(station.StationToken, true)
    if err != nil {
        panic(err)
    }
}
```

I also fixed a typo in `Station.Feedback.ThumbsDown` with the JSON tag.
