### PR TITLE
ci: bump Go toolchain to 1.26.4 to clear stdlib vulnerabilities

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 git-cliff         = "2.12.0"
-go                = "1.26.1"
+go                = "1.26.4"
 golangci-lint     = "2.11.3"
 just              = "1.46.0"
 "pipx:pre-commit" = "4.5.1"


### PR DESCRIPTION
## Summary

Bumps the pinned Go toolchain in `mise.toml` from **1.26.1 → 1.26.4** to clear Go standard-library vulnerabilities flagged by `govulncheck` in CI.

| | |
|---|---|
| **Impact** | 1 file changed (+1 / −1) |
| **Risk** | 🟢 Low — patch-level toolchain bump, no source changes |
| **Review time** | ~2 min |
| **Type** | `ci` / chore (build tooling) |

## What changed

⚙️ **Config**
- `M mise.toml` — `go = "1.26.1"` → `go = "1.26.4"`

No `mise.lock` is tracked, so this single line is the complete change.

## Why

The `build` check was failing on **every open PR** — including pure GitHub-Actions bumps (#34, #35, #29) that can't touch the Go build. Root cause was shared: the `govulncheck ./...` step flagged **8 Go standard-library CVEs in the pinned toolchain `go1.26.1`**:

| Advisory | Package | Fixed in |
|----------|---------|----------|
| GO-2026-5039 | net/textproto | go1.26.4 |
| GO-2026-5037 | crypto/x509 | go1.26.4 |
| GO-2026-4971 | net | go1.26.3 |
| GO-2026-4947 | crypto/x509 | go1.26.2 |
| GO-2026-4946 | crypto/x509 | go1.26.2 |
| GO-2026-4918 | net/http | go1.26.3 |
| GO-2026-4870 | crypto/tls | go1.26.2 |
| GO-2026-4866 | crypto/x509 | go1.26.2 |

Because it's a toolchain-version issue, the failure reproduced identically across PRs regardless of content. `go1.26.4` is the current latest patch and clears all 8.

## How this was tested

Verified locally on go1.26.4, then confirmed green in CI on this PR:

```
go build ./...      → OK
go test ./...        → ok  github.com/unclesp1d3r/gopiano
govulncheck ./...    → No vulnerabilities found  (exit 0)
```

## Breaking changes

None. Patch-level toolchain bump; `go.mod` language version (`go 1.25.8`) is unchanged.

## Knock-on effect

Once merged to `master`, the shared CI failure clears for the whole PR queue. After the bots rebase:
- **#37, #35, #34, #29** — only failure was govulncheck → will go green
- **#28** — already clean
- **#22** — still needs separate attention (merge conflict + real lint failure)

## Follow-up (not in this PR)

`build-test.yml` and `release.yml` pin `govulncheck@latest` against an exact Go patch, so any newly-published stdlib CVE will re-break CI until the pin is bumped. Worth automating the mise Go-version bump or relaxing the pin.

## Checklist

- [x] No source/behavior changes
- [x] `build`, `test`, `govulncheck` pass locally and in CI
- [x] No secrets or hardcoded values introduced
- [x] Commit signed off (DCO) and GPG-signed
